### PR TITLE
Fixed `Location` header from `MapEdit` login contains extra parameters

### DIFF
--- a/openmaps_auth/signals.py
+++ b/openmaps_auth/signals.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 from django.contrib.auth.signals import user_logged_in
 from django.dispatch import receiver
+from os.path import split
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ def openmaps_login(sender, **kwargs):
     login_resp = requests.post(
         login_url, allow_redirects=False, cookies=cookies, data=login_data
     )
-    if login_resp.headers.get("location") != settings.OSM_BASE_URL:
+    if split(login_resp.headers.get("location"))[0] != settings.OSM_BASE_URL:
         logger.error(f"Failed to login into OSM for user: {user.email}")
         raise Exception
     else:


### PR DESCRIPTION
MapEdit returns `http://mapedit/login?referer=&username=david%40openstreetmap.org` but `openmaps-auth` is expecting `http://mapedit`.


```
Failed to login into OSM for user: david@openstreetmap.org
Internal Server Error: /callback
Traceback (most recent call last):
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/share/auth/openmaps_auth/views.py", line 51, in callback
    response = social_django.views.complete(
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/views/decorators/cache.py", line 57, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/social_django/utils.py", line 46, in wrapper
    return func(request, backend, *args, **kwargs)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/social_django/views.py", line 31, in complete
    return do_complete(request.backend, _do_login, user=request.user,
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/social_core/actions.py", line 70, in do_complete
    login(backend, user, social_user)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/social_django/views.py", line 102, in _do_login
    login(backend.strategy.request, user)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/contrib/auth/__init__.py", line 135, in login
    user_logged_in.send(sender=user.__class__, request=request, user=user)
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/dispatch/dispatcher.py", line 170, in send
    return [
  File "/usr/share/auth/venv/lib64/python3.9/site-packages/django/dispatch/dispatcher.py", line 171, in <listcomp>
    (receiver, receiver(signal=self, sender=sender, **named))
  File "/usr/share/auth/openmaps_auth/signals.py", line 48, in openmaps_login
    raise Exception
Exception
```
