### PR TITLE
Okta Support

### DIFF
--- a/openmaps_auth/backends.py
+++ b/openmaps_auth/backends.py
@@ -2,12 +2,16 @@ import re
 import os
 import secrets
 import time
+from urllib.parse import urljoin, urlparse, urlunparse
 from xml.dom import minidom
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from jose import jwt
+from social_core.backends.okta_openidconnect import (
+    OktaOpenIdConnect as BaseOktaOpenIdConnect,
+)
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_core.backends.openstreetmap import (
     OpenStreetMapOAuth as BaseOpenStreetMapOAuth,
@@ -99,6 +103,33 @@ class LoginGovOpenIdConnect(OpenIdConnectAuth):
         user_details["email_verified"] = response["email_verified"]
         user_details["username"] = username
         return user_details
+
+
+class OktaOpenIdConnect(BaseOktaOpenIdConnect):
+    def get_redirect_uri(self, state=None):
+        return self.setting("REDIRECT_URI", super().get_redirect_uri(state))
+
+    # This fix for Okta OIDC configuration URLs copied from:
+    # https://github.com/python-social-auth/social-core/pull/663
+    def oidc_config_url(self):
+        # https://developer.okta.com/docs/reference/api/oidc/#well-known-openid-configuration
+        url = urlparse(self.api_url())
+
+        # If the URL path does not contain an authorizedServerId, we need
+        # to truncate the path in order to generate a proper openid-configuration
+        # URL.
+        if url.path == "/oauth2/":
+            url = url._replace(path="")
+
+        return urljoin(
+            urlunparse(url),
+            "./.well-known/openid-configuration?client_id={}".format(
+                self.setting("KEY")
+            ),
+        )
+
+    def oidc_config(self):
+        return self.get_json(self.oidc_config_url())
 
 
 class OpenStreetMapOAuth(BaseOpenStreetMapOAuth):

--- a/openmaps_auth/settings/common.py
+++ b/openmaps_auth/settings/common.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from django.core.exceptions import ImproperlyConfigured
 import environ
 
 env = environ.FileAwareEnv()
@@ -121,6 +122,17 @@ if OPENMAPS_AUTH_BACKEND == "login-gov":
     SOCIAL_AUTH_LOGIN_GOV_REDIRECT_URI = OPENMAPS_AUTH_REDIRECT_URI
     if OPENMAPS_AUTH_OIDC_ENDPOINT:
         SOCIAL_AUTH_LOGIN_GOV_OIDC_ENDPOINT = OPENMAPS_AUTH_OIDC_ENDPOINT
+elif OPENMAPS_AUTH_BACKEND == "okta-openidconnect":
+    AUTHENTICATION_BACKENDS = (
+        "openmaps_auth.backends.OktaOpenIdConnect",
+    ) + AUTHENTICATION_BACKENDS
+    SOCIAL_AUTH_OKTA_OPENIDCONNECT_KEY = OPENMAPS_AUTH_KEY
+    SOCIAL_AUTH_OKTA_OPENIDCONNECT_SECRET = OPENMAPS_AUTH_SECRET
+    SOCIAL_AUTH_OKTA_OPENIDCONNECT_REDIRECT_URI = OPENMAPS_AUTH_REDIRECT_URI
+    if OPENMAPS_AUTH_OIDC_ENDPOINT:
+        SOCIAL_AUTH_OKTA_OPENIDCONNECT_API_URL = OPENMAPS_AUTH_OIDC_ENDPOINT
+    else:
+        raise ImproperlyConfigured("Must provide endpoint for Okta")
 elif OPENMAPS_AUTH_BACKEND == "openstreetmap":
     AUTHENTICATION_BACKENDS = (
         "openmaps_auth.backends.OpenStreetMapOAuth",


### PR DESCRIPTION
Adds support for using Okta as a social authentication backend.  The `OktaOpenIdConnect` class needs a patch (via python-social-auth/social-core#663) to use the correct URLs for self-discovery -- for example, to correctly the OAuth2 endpoints you'd use:

```
OPENMAPS_AUTH_OIDC_ENDPOINT=https://dev-NNNNNNNN.okta.com/oauth2
```

Without the patch `social_core` would hit `https://dev-NNNNNNNN.okta.com/oauth2/.well-known/openid-configuration` instead of the correct endpoint of `https://dev-NNNNNNNN.okta.com/.well-known/openid-configuration`.